### PR TITLE
feat: remove limit of coin pairs

### DIFF
--- a/zvt_ccxt/accounts/ccxt_account.py
+++ b/zvt_ccxt/accounts/ccxt_account.py
@@ -8,6 +8,7 @@ from zvt_ccxt.settings import COIN_EXCHANGES
 
 
 class CCXTAccount(object):
+    exchange_cache = {}
     exchanges = COIN_EXCHANGES
     exchange_conf = {}
 
@@ -37,9 +38,13 @@ class CCXTAccount(object):
 
     @classmethod
     def get_ccxt_exchange(cls, exchange_str) -> ccxt.Exchange:
+        if cls.exchange_cache.get(exchange_str):
+            return cls.exchange_cache[exchange_str]
+
         exchange = eval("ccxt.{}()".format(exchange_str))
         exchange.apiKey = cls.exchange_conf[exchange_str]['apiKey']
         exchange.secret = cls.exchange_conf[exchange_str]['secret']
         # set to your proxies if need
         exchange.proxies = {'http': zvt_env['http_proxy'], 'https': zvt_env['https_proxy']}
+        cls.exchange_cache[exchange_str] = exchange
         return exchange

--- a/zvt_ccxt/recorders/coin_kdata_recorder.py
+++ b/zvt_ccxt/recorders/coin_kdata_recorder.py
@@ -28,7 +28,7 @@ class CoinKdataRecorder(FixedCycleDataRecorder):
                  codes=None,
                  batch_size=10,
                  force_update=True,
-                 sleeping_time=10,
+                 sleeping_time=1,
                  default_size=2000,
                  real_time=False,
                  fix_duplicate_way='ignore',

--- a/zvt_ccxt/recorders/coin_recorder.py
+++ b/zvt_ccxt/recorders/coin_recorder.py
@@ -1,17 +1,17 @@
 import pandas as pd
-
 from zvt.contract.api import df_to_db
 from zvt.contract.recorder import Recorder
+
 from zvt_ccxt.accounts import CCXTAccount
 from zvt_ccxt.domain import Coin
-from zvt_ccxt.settings import COIN_EXCHANGES, COIN_PAIRS
+from zvt_ccxt.settings import COIN_EXCHANGES
 
 
 class CoinMetaRecorder(Recorder):
     provider = 'ccxt'
     data_schema = Coin
 
-    def __init__(self, batch_size=10, force_update=False, sleeping_time=10, exchanges=COIN_EXCHANGES) -> None:
+    def __init__(self, batch_size=10, force_update=False, sleeping_time=1, exchanges=COIN_EXCHANGES) -> None:
         super().__init__(batch_size, force_update, sleeping_time)
         self.exchanges = exchanges
 
@@ -30,6 +30,8 @@ class CoinMetaRecorder(Recorder):
 
                 aa = []
                 for market in markets:
+                    if not market['active']:
+                        continue
                     if markets_type == dict:
                         name = market
                         code = market
@@ -38,8 +40,7 @@ class CoinMetaRecorder(Recorder):
                         code = market['symbol']
                         name = market['symbol']
 
-                    if name not in COIN_PAIRS:
-                        continue
+
                     aa.append(market)
 
                     security_item = {


### PR DESCRIPTION
1. add active check for market pair in coin meta, to filter invalid pair in kdata request
2. add cache for exchange instance

这个pr主要尝试移除交易对的限制，判断active去除无效交易对，同时缓存exchange实例，避免使用代理时拉数据报错。

#1 
